### PR TITLE
Refactor snippet loading logic to prevent duplicate execution and enh…

### DIFF
--- a/router.js
+++ b/router.js
@@ -32,6 +32,9 @@ async function router() {
     }
     document.querySelector("#content").innerHTML = html;
 
+    // Reset snippet details loaded flag before reloading scripts
+    window.snippetDetailsLoaded = false;
+
     // Execute scripts in the loaded HTML
     reloadScripts();
 

--- a/searchengine.js
+++ b/searchengine.js
@@ -54,14 +54,6 @@ function displayData(_data) {
         resultArea.innerHTML += htmlBody;
         updatePagination();
     }
-
-    // Append router to handle navigation for newly added links
-    resultArea.querySelectorAll("[data-link]").forEach(link => {
-        link.addEventListener("click", e => {
-            e.preventDefault();
-            navigateTo(link.href);
-        });
-    });
 }
 
 function changePage(newPage) {

--- a/snippets/details.js
+++ b/snippets/details.js
@@ -1,4 +1,8 @@
 function loadSnippetDetails() {
+    // Prevent duplicate execution
+    if (window.snippetDetailsLoaded) return;
+    window.snippetDetailsLoaded = true;
+    
     // Extract snippet ID from URL
     const pathParts = location.pathname.split('/');
     const snippetId = pathParts.length >= 3 ? decodeURIComponent(pathParts[2]) : null;
@@ -22,14 +26,19 @@ async function fetchSnippetData(file, snippetId) {
 
 function displaySnippetDetails(data, snippetId) {
     let snippet = null;
-    // If the id is a number and exists as index
+    // Convert snippetId to number if it's numeric
     const numeric = Number.parseInt(snippetId, 10);
-    if (!Number.isNaN(numeric) && data[numeric]) {
-        snippet = data[numeric];
-    } else {
-        // Try to find by id or slug field
+    
+    // Try to find by numeric id first, then by other fields
+    if (!Number.isNaN(numeric)) {
+        snippet = data.find?.(s => s.id === numeric);
+    }
+    
+    // If not found by numeric id, try string matching
+    if (!snippet) {
         snippet = data.find?.(s => s.id === snippetId || s.slug === snippetId || s.title === snippetId);
     }
+    
     if (!snippet) {
         document.querySelector("#content").innerHTML += "<p>Error: Snippet not found.</p>";
         return;


### PR DESCRIPTION
This pull request improves the handling of snippet detail loading and refines how snippet data is matched and displayed. The main changes focus on preventing duplicate detail loads, ensuring snippet lookup is robust, and cleaning up navigation logic for newly loaded content.

Improvements to snippet details loading:

* Added a global `window.snippetDetailsLoaded` flag in `snippets/details.js` and `router.js` to prevent duplicate execution of the snippet details loader when navigating or reloading content. [[1]](diffhunk://#diff-c1464ee666dd329f5c89b19e8a6f785b60aadf75c99687031b8ffa3576acaeacR2-R5) [[2]](diffhunk://#diff-a73fe0e0bce14920155c1577b261b025ced6d28bf11c113f8b86cb5f429ee471R35-R37)

Enhancements to snippet lookup logic:

* Updated `displaySnippetDetails` in `snippets/details.js` to first attempt finding a snippet by numeric `id`, then fall back to string matching against `id`, `slug`, or `title`, making the lookup more robust and flexible.

Navigation and event handling cleanup:

* Removed redundant router event attachment for newly added links in `searchengine.js`, streamlining the handling of navigation after search results are rendered